### PR TITLE
Feature/upgrade to spring boot 1.4.ga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target/
 .classpath
 .springBeans
 *.log
+
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 	<properties>
 		<java.version>1.8</java.version>
 		<json-path.version>2.0.0</json-path.version>
-		<spring-hateoas.version>0.20.0.BUILD-SNAPSHOT</spring-hateoas.version>
+		<spring-hateoas.version>0.20.0.RELEASE</spring-hateoas.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.0.M3</version>
+		<version>1.4.0.RELEASE</version>
 	</parent>
 
 	<properties>

--- a/src/test/java/org/springsource/restbucks/order/web/OrderResourceIntegrationTest.java
+++ b/src/test/java/org/springsource/restbucks/order/web/OrderResourceIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.springsource.restbucks.order.web;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -34,7 +35,7 @@ public class OrderResourceIntegrationTest extends AbstractWebIntegrationTest {
 	@Test
 	public void exposesOrdersResourceViaRootResource() throws Exception {
 
-		mvc.perform(get("/")).//
+		mvc.perform(get("/").accept(HAL_JSON)).//
 				andDo(MockMvcResultHandlers.print()).//
 				andExpect(status().isOk()). //
 				andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON)). //

--- a/src/test/java/org/springsource/restbucks/payment/web/PaymentProcessIntegrationTest.java
+++ b/src/test/java/org/springsource/restbucks/payment/web/PaymentProcessIntegrationTest.java
@@ -17,6 +17,7 @@ package org.springsource.restbucks.payment.web;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -116,8 +117,8 @@ public class PaymentProcessIntegrationTest extends AbstractWebIntegrationTest {
 
 		LOG.info("Accessing root resource…");
 
-		MockHttpServletResponse response = mvc.perform(get("/")). //
-				andExpect(status().isOk()). //
+		MockHttpServletResponse response = mvc.perform(get("/").accept(HAL_JSON)). //
+                andExpect(status().isOk()). //
 				andExpect(linkWithRelIsPresent(ORDERS_REL)). //
 				andReturn().getResponse();
 
@@ -224,7 +225,7 @@ public class PaymentProcessIntegrationTest extends AbstractWebIntegrationTest {
 		ResultActions action = mvc.perform(put(paymentLink.getHref()).//
 				content("\"1234123412341234\"").//
 				contentType(MediaType.APPLICATION_JSON).//
-				accept(MediaTypes.HAL_JSON));
+				accept(HAL_JSON));
 
 		MockHttpServletResponse result = action.andExpect(status().isCreated()). //
 				andExpect(linkWithRelIsPresent(ORDER_REL)). //
@@ -320,7 +321,7 @@ public class PaymentProcessIntegrationTest extends AbstractWebIntegrationTest {
 		return mvc
 				.perform( //
 						delete(receiptLink.getHref()).//
-								accept(MediaTypes.HAL_JSON))
+								accept(HAL_JSON))
 				. //
 				andExpect(status().isOk()). //
 				andReturn().getResponse();


### PR DESCRIPTION
This pull request aims to update master to recent release versions of Spring Boot and HATEOAS, including the removal of SNAPSHOT dependencies.

Integration tests had to be adjusted to add correct accept headers for root discovery to pass, which seems to be correct anyway.
