### PR TITLE
move actuator from observability profile to default

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -83,6 +83,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-rest</artifactId>
 		</dependency>
 
@@ -207,11 +212,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 					<groupId>org.springframework.experimental</groupId>
 					<artifactId>spring-modulith-observability</artifactId>
 					<version>${spring-modulith.version}</version>
-				</dependency>
-
-				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-actuator</artifactId>
 				</dependency>
 
 				<dependency>


### PR DESCRIPTION
I wonder if this might be acceptable? I'd like to have the actuators in every case to use from Kubernetes probes.

(Also happy to contribute helm chart if it would be appreciated)