### PR TITLE
Remove outdated comment about Optional.orElseThrow(...)

### DIFF
--- a/server/src/main/java/org/springsource/restbucks/payment/PaymentServiceImpl.java
+++ b/server/src/main/java/org/springsource/restbucks/payment/PaymentServiceImpl.java
@@ -53,7 +53,6 @@ class PaymentServiceImpl implements PaymentService {
 			throw new PaymentFailed(order, "Order already paid!");
 		}
 
-		// Using Optional.orElseThrow(…) doesn't work due to https://bugs.openjdk.java.net/browse/JDK-8054569
 		var creditCard = cards.findByNumber(creditCardNumber)
 				.orElseThrow(() -> new PaymentFailed(order,
 						String.format("No credit card found for number: %s", creditCardNumber)));


### PR DESCRIPTION
This comment was written in 2015 and the code was changed to use `Optional.orElseThrow(...)` in 2021, so this comment is no long valid.
> // Using Optional.orElseThrow(…) doesn't work due to https://bugs.openjdk.java.net/browse/JDK-8054569

