### PR TITLE
* Add Oliver bp-native profile

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -310,9 +310,31 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 
 		</profile>
 
+<!--		<profile>-->
+
+<!--			<id>native</id>-->
+
+<!--			<properties>-->
+<!--				<maven.test.skip>true</maven.test.skip>-->
+<!--			</properties>-->
+
+<!--			<build>-->
+
+<!--				<defaultGoal>native:compile</defaultGoal>-->
+
+<!--				<plugins>-->
+<!--					<plugin>-->
+<!--						<groupId>org.graalvm.buildtools</groupId>-->
+<!--						<artifactId>native-maven-plugin</artifactId>-->
+<!--					</plugin>-->
+<!--				</plugins>-->
+
+<!--			</build>-->
+
+<!--		</profile>-->
 		<profile>
 
-			<id>native</id>
+			<id>native-bp</id>
 
 			<properties>
 				<maven.test.skip>true</maven.test.skip>
@@ -320,12 +342,28 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 
 			<build>
 
-				<defaultGoal>native:compile</defaultGoal>
+				<defaultGoal>spring-boot:build-image</defaultGoal>
 
 				<plugins>
 					<plugin>
-						<groupId>org.graalvm.buildtools</groupId>
-						<artifactId>native-maven-plugin</artifactId>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-maven-plugin</artifactId>
+						<configuration>
+							<image>
+								<buildpacks>
+									<buildpack>paketobuildpacks/java-native-image:beta</buildpack>
+								</buildpacks>
+								<builder>paketobuildpacks/builder-jammy-buildpackless-tiny</builder>
+							</image>
+						</configuration>
+						<executions>
+							<execution>
+								<id>process-aot</id>
+								<goals>
+									<goal>process-aot</goal>
+								</goals>
+							</execution>
+						</executions>
 					</plugin>
 				</plugins>
 
@@ -364,20 +402,20 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<executable>true</executable>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.springframework.boot.experimental</groupId>
-						<artifactId>spring-boot-thin-layout</artifactId>
-						<version>1.0.31.RELEASE</version>
-					</dependency>
-				</dependencies>
-			</plugin>
+<!--			<plugin>-->
+<!--				<groupId>org.springframework.boot</groupId>-->
+<!--				<artifactId>spring-boot-maven-plugin</artifactId>-->
+<!--				<configuration>-->
+<!--					<executable>true</executable>-->
+<!--				</configuration>-->
+<!--				<dependencies>-->
+<!--					<dependency>-->
+<!--						<groupId>org.springframework.boot.experimental</groupId>-->
+<!--						<artifactId>spring-boot-thin-layout</artifactId>-->
+<!--						<version>1.0.31.RELEASE</version>-->
+<!--					</dependency>-->
+<!--				</dependencies>-->
+<!--			</plugin>-->
 
 		</plugins>
 	</build>


### PR DESCRIPTION
* Comment out native profile customization, so that the default one provided by spring boot parent can add its required                     `<BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>` to the spring boot plugin

* Comment out the spring-boot-maven-plugin customization
  * that turns the jar into an "executable" (`<executable>true</executable>`) that makes the jar no longer a jar (and hence can't be properly detected by BP)
* that uses the spring boot thin layout that removes the Spring-Boot-Lib from the manifest which is required for BP detection

 Now using `./mvnw -Pnative,native-bp` BP will do the native build; I've tested it, it works fine

 ```
 2024-04-05T17:50:24.251Z  INFO 1 --- [restbucks] [           main] org.springsource.restbucks.Restbucks     : Started Restbucks in 0.377 seconds (process running for 0.411)
 ```

 Replacing `java-native-image:beta` with `java:beta`, and running `./mvnw -Pnative-bp` should also work for a regular jar