### PR TITLE
Start building against Spring Framework 6.2.0-M5 snapshots

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -251,11 +251,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 					<artifactId>opentelemetry-exporter-zipkin</artifactId>
 				</dependency>
 
-				<dependency>
-					<groupId>net.ttddyy.observation</groupId>
-					<artifactId>datasource-micrometer-spring-boot</artifactId>
-					<version>${datasourceMicrometerSpringBootVersion}</version>
-				</dependency>
+				<!-- Comment in to produce database spans -->
+<!--				<dependency>-->
+<!--					<groupId>net.ttddyy.observation</groupId>-->
+<!--					<artifactId>datasource-micrometer-spring-boot</artifactId>-->
+<!--					<version>${datasourceMicrometerSpringBootVersion}</version>-->
+<!--				</dependency>-->
 
 				<dependency>
 					<groupId>org.springframework.boot</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -21,7 +21,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
 		<java.version>22</java.version>
 		<lombok.version>1.18.32</lombok.version>
 		<jmolecules.version>2023.1.3</jmolecules.version>
-		<spring-framework.version>6.2.0-M3</spring-framework.version>
+		<spring-framework.version>6.2.0-SNAPSHOT</spring-framework.version>
 		<spring-modulith.version>1.2.0-SNAPSHOT</spring-modulith.version>
 	</properties>
 

--- a/server/src/test/java/org/springsource/restbucks/AbstractWebIntegrationTest.java
+++ b/server/src/test/java/org/springsource/restbucks/AbstractWebIntegrationTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.Assert;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -51,8 +50,8 @@ public abstract class AbstractWebIntegrationTest {
 	@BeforeEach
 	void setUp() {
 
-		this.mvc = MockMvcTester.create(MockMvcBuilders.webAppContextSetup(context).//
-				defaultRequest(MockMvcRequestBuilders.get("/").locale(Locale.US)).//
+		this.mvc = MockMvcTester.from(context, builder ->//
+				builder.defaultRequest(MockMvcRequestBuilders.get("/").locale(Locale.US)).//
 				build());
 	}
 


### PR DESCRIPTION
This restores proper AOT support using Spring Framework snapshots, see https://github.com/spring-projects/spring-framework/issues/33069.

I've also added an extra commit that showcases a simpler setup for `MockMvcTester`.