### PR TITLE
Update submit_payments.sh

### DIFF
--- a/server/scripts/submit_payments.sh
+++ b/server/scripts/submit_payments.sh
@@ -3,7 +3,7 @@
 ##### MAKE PAYMENTS
 
 pending_orders_json=$(http ":8080/orders/search/findByStatus?status=PAYMENT_EXPECTED")
-pending_order_links=($(echo "$pending_orders_json" | jq -r '._embedded["restbucks:orders"][].["_links"]["self"]["href"]'))
+pending_order_links=($(echo "$pending_orders_json" | jq -r '._embedded["restbucks:orders"][]._links.self.href'))
 
 echo "Orders pending payment: ${#pending_order_links[@]}"
 


### PR DESCRIPTION
The original pending_order_links appears to not work, at least on macos with zsh. Corrected as follows.